### PR TITLE
upload rate limiting using IP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    // Adaptive traffic throttler를 위한 Bucket4j 의존성 추가
+    implementation("com.github.vladimir-bukhtoyarov:bucket4j-core:8.0.1")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/kotlin/com/flowery/flowerygateway/controller/TrafficController.kt
+++ b/src/main/kotlin/com/flowery/flowerygateway/controller/TrafficController.kt
@@ -1,0 +1,49 @@
+package com.flowery.flowerygateway.controller
+
+import com.flowery.flowerygateway.service.TrafficLimitService
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+
+@Controller
+@RequestMapping("/api")
+class TrafficController(private val trafficLimitService: TrafficLimitService) {
+
+    /**
+     *  서비스에서 요청 허용 여부 확인
+     *  허용, 버킷에서 토큰(요청 가능 횟수)을 차감하고 요청을 처리
+     *  거부, 버킷이 비어 있으면 요청을 거부하고 429 Too Many Requests 응답을 반환
+     * **/
+    @GetMapping("/limited-endpoint")
+    @ResponseBody
+    fun limitedEndpoint(request : HttpServletRequest): ResponseEntity<String> {
+        val clientIp = getClientIp(request)
+
+        return if (trafficLimitService.isRequestAllowed(clientIp)){
+            ResponseEntity.ok("Request accepted. Your IP: $clientIp")
+        }
+        else {
+            ResponseEntity
+                .status(HttpStatus.TOO_MANY_REQUESTS)
+                .header("Retry-After", "60") // 제한 해제까지 60초
+                .body("Too many requests. Please try again later.")
+        }
+    }
+
+    /**
+     * 클라이언트 IP 가져오는 메서드
+     **/
+    fun getClientIp(request: HttpServletRequest): String {
+        val xfHeader = request.getHeader("X-Forwarded-For")
+        return if (xfHeader != null) {
+            xfHeader.split(",").first() // xfHeader의 첫 번째 IP인 클라이언트 IP
+        } else {
+            request.remoteAddr // 클라이언트가 직접 서버에 직접 요청을 보낸 경우
+        }
+    }
+
+}

--- a/src/main/kotlin/com/flowery/flowerygateway/service/TrafficLimitService.kt
+++ b/src/main/kotlin/com/flowery/flowerygateway/service/TrafficLimitService.kt
@@ -1,0 +1,33 @@
+package com.flowery.flowerygateway.service
+
+import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
+import io.github.bucket4j.Bucket
+import io.github.bucket4j.Bandwidth
+import java.time.Duration
+
+@Service
+class TrafficLimitService {
+
+    // IP별로 Bucket을 관리
+    private val buckets: ConcurrentHashMap<String, Bucket> = ConcurrentHashMap()
+
+    // IP에 해당하는 Bucket 생성 또는 조회
+    fun getBucket(ip: String): Bucket{
+        val bucket = buckets.computeIfAbsent(ip) {
+            Bucket.builder()
+                .addLimit(Bandwidth.simple(10, Duration.ofMinutes(1)) )// 분당 10 요청
+                .build()
+        }
+        return bucket
+    }
+
+    // 요청을 처리할 수 있는지 확인
+    fun isRequestAllowed(ip: String): Boolean {
+        val bucket = getBucket(ip)
+        val result =  bucket.tryConsume(1)
+
+        return result
+    }
+
+}


### PR DESCRIPTION
@KyumKyum 님
가장 기본적인 IP 기반 트래픽 처리를 구현해봤습니다.
버킷은 1분당 10로 제한해서 postman으로 10번 이상 send 했을 경우 버킷의 토큰이 하나씩 차감되도록하고
다 차감되었을 경우 429 에러가 나도록 구현했습니다.
일단 기존 Test controller, service가 아닌 트랙픽 controller, service를 따로 파일을 팠습니다.
나중에 자동 로그인이라던지, 조회 등에서 사용에 따라 트래픽 처리한 내용을 합치면 될 것 같습니다. 
혹시나 IP 트래픽 처리가 아닌 다른 것에 대한 구현을 원하시면 말해주세요~