### PR TITLE
feat: 사용자의 로그인, 팔로우/언팔로우 활동 시 상태 서버에 notify 요청 전송

### DIFF
--- a/src/main/kotlin/com/flowery/flowerygateway/config/RestTemplateConfig.kt
+++ b/src/main/kotlin/com/flowery/flowerygateway/config/RestTemplateConfig.kt
@@ -1,0 +1,13 @@
+package com.flowery.flowerygateway.config
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestTemplate
+
+@Configuration
+class RestTemplateConfig {
+
+    @Bean
+    fun restTemplate(): RestTemplate {
+        return RestTemplate()
+    }
+}

--- a/src/main/kotlin/com/flowery/flowerygateway/controller/AuthClientController.kt
+++ b/src/main/kotlin/com/flowery/flowerygateway/controller/AuthClientController.kt
@@ -2,6 +2,7 @@ package com.flowery.flowerygateway.controller
 
 import com.flowery.flowerygateway.dto.*
 import com.flowery.flowerygateway.service.AuthClientService
+import com.flowery.flowerygateway.service.StatusNotifierService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -14,7 +15,8 @@ import reactor.core.publisher.Mono
 
 @RestController
 @RequestMapping("/api/main")
-class AuthClientController(@Autowired val authClientService: AuthClientService) {
+class AuthClientController(val authClientService: AuthClientService,
+                            val statusNotifierService : StatusNotifierService) {
 
     @PutMapping("/gardener")
     fun signup(@RequestBody signupRequest: SignupRequest): Mono<ResponseEntity<SignupResponse>> {
@@ -23,6 +25,7 @@ class AuthClientController(@Autowired val authClientService: AuthClientService) 
 
     @PostMapping("/login")
     fun login(@RequestBody loginRequest: LoginRequest): Mono<ResponseEntity<LoginResponse>> {
+        //statusNotifierService.notifyActivity(loginRequest.ident)
         return authClientService.login(loginRequest)
 
     }

--- a/src/main/kotlin/com/flowery/flowerygateway/controller/FollowerController.kt
+++ b/src/main/kotlin/com/flowery/flowerygateway/controller/FollowerController.kt
@@ -2,6 +2,7 @@ package com.flowery.flowerygateway.controller
 
 import com.flowery.flowerygateway.dto.RemoveFollowerRequestDTO
 import com.flowery.flowerygateway.service.FollowerService
+import com.flowery.flowerygateway.service.StatusNotifierService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -13,10 +14,12 @@ import reactor.core.publisher.Mono
 import java.util.*
 
 @RestController
-class FollowerController(private val followerService: FollowerService) {
-
+class FollowerController(private val followerService: FollowerService,
+                         private val statusNotifierService: StatusNotifierService)
+{
     @DeleteMapping("gardener/follower")
     fun removeFollowers(@RequestBody removeFollowerRequestDTO : RemoveFollowerRequestDTO) : Mono<ResponseEntity<String>> {
+        statusNotifierService.notifyActivity(removeFollowerRequestDTO.followingId)
         return followerService.removeFollower(removeFollowerRequestDTO)
     }
 

--- a/src/main/kotlin/com/flowery/flowerygateway/controller/FollowingController.kt
+++ b/src/main/kotlin/com/flowery/flowerygateway/controller/FollowingController.kt
@@ -3,6 +3,7 @@ package com.flowery.flowerygateway.controller
 import com.flowery.flowerygateway.dto.FollowingRequestDTO
 import com.flowery.flowerygateway.dto.UnfollowingRequestDTO
 import com.flowery.flowerygateway.service.FollowingService
+import com.flowery.flowerygateway.service.StatusNotifierService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -11,10 +12,12 @@ import reactor.core.publisher.Mono
 import java.util.*
 
 @RestController
-class FollowingController(@Autowired val followingService : FollowingService) {
+class FollowingController(@Autowired val followingService : FollowingService,
+                            @Autowired val statusNotifierService: StatusNotifierService) {
     // add following -> Following Request DTO (followerId, followingId)
     @PostMapping("gardener/newfollowing")
     fun newFollowing(followingRequestDTO: FollowingRequestDTO): Mono<ResponseEntity<String>> {
+        statusNotifierService.notifyActivity(followingRequestDTO.followingId)
         return followingService.addFollowing(followingRequestDTO)
             .flatMap { response ->
                 if (response.body == null || response.body!!.get("ok") == false) {
@@ -48,6 +51,7 @@ class FollowingController(@Autowired val followingService : FollowingService) {
     // delete following -> Unfollowing Request DTO (followerId, followingId)
     @DeleteMapping("gardener/unfollowing")
     fun unfollowing(unfollowingRequestDTO: UnfollowingRequestDTO): Mono<ResponseEntity<String>> {
+        statusNotifierService.notifyActivity(unfollowingRequestDTO.followingId)
         return followingService.deleteFollowing(unfollowingRequestDTO)
             .flatMap { response ->
                 if (response.body == null || response.body!!.get("ok") == false) {

--- a/src/main/kotlin/com/flowery/flowerygateway/dto/StatusUpdateRequestDto.kt
+++ b/src/main/kotlin/com/flowery/flowerygateway/dto/StatusUpdateRequestDto.kt
@@ -1,0 +1,9 @@
+package com.flowery.flowerygateway.dto
+
+import java.time.LocalDateTime
+import java.util.*
+
+data class StatusUpdateRequestDto (
+    val userId: UUID,
+    val timestamp: LocalDateTime
+)

--- a/src/main/kotlin/com/flowery/flowerygateway/service/FollowerService.kt
+++ b/src/main/kotlin/com/flowery/flowerygateway/service/FollowerService.kt
@@ -14,7 +14,6 @@ import java.util.*
 @Service("followerService")
 class FollowerService(@Qualifier("followingServiceClient") private val webClient : WebClient,
                       private val followRequestValidator: FollowRequestValidator) {
-
     //팔로워 조회
     fun getFollowerList(id: UUID): Mono<ResponseEntity<List<UUID>>> {
         return webClient.get() //HTTP GET 요청 생성

--- a/src/main/kotlin/com/flowery/flowerygateway/service/StatusNotifierService.kt
+++ b/src/main/kotlin/com/flowery/flowerygateway/service/StatusNotifierService.kt
@@ -1,0 +1,36 @@
+package com.flowery.flowerygateway.service
+
+import com.flowery.flowerygateway.dto.StatusUpdateRequestDto
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+import java.time.LocalDateTime
+import java.util.*
+
+@Service
+class StatusNotifierService (private val restTemplate: RestTemplate,
+                             @Value("\${status-server.url}") private val statusServerUrl: String){
+    private val log = LoggerFactory.getLogger(StatusNotifierService::class.java)
+
+    fun notifyActivity(userId: UUID): Boolean {
+        val request = StatusUpdateRequestDto(
+            userId = userId,
+            timestamp = LocalDateTime.now()
+        )
+        val url = "$statusServerUrl/status/update"
+        return try {
+            val result = restTemplate.postForObject(url, request, Boolean::class.java)
+            if (result == true) {
+                log.info(" status server 전송 성공 - userId : $userId")
+                true
+            } else {
+                log.warn(" status server 응답이 false - userId : $userId")
+                false
+            }
+        } catch (e: Exception) {
+            log.error(" status server 전송 실패 - userId: $userId, error: ${e.message}", e)
+            false
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=flowery-gateway

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+status-server:
+  url: http://localhost:8080


### PR DESCRIPTION
이 전에 pr올린건 main으로 잘못 올렸습니다.. 이걸로 확인 부탁드려요

사용자의 로그인, 팔로우/언팔로우 활동 시 상태 서버에 notify 요청 전송
- RestTemplate 설정
- StatusNotifierService 작성
- 각 컨트롤러에 notifyActivity 호출 추가 (로그인 제외, 발생한 문제는 규민님과 태희님께 카톡 드렸습니다. 확인해주시면 감사하겠습니다)
@KyumKyum @taeheee02 

